### PR TITLE
Issue47 - Merging fix for unknown download Content-Length - #47

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -272,7 +272,7 @@ def download_patch(patch_url):
     try:
         u = urlopen(url)
     except Exception, err:
-        print("Failed to Download Patch!")
+        print("...ERR: Failed to Download Patch!")
         print("Error: " + str(err))
         sys.exit(3)
         
@@ -286,8 +286,11 @@ def download_patch(patch_url):
     try:
         file_size = int(meta.getheaders("Content-Length")[0])
         size_ok = True
-    except Exception, err:
-        print("Failed to get download size- will skip available disk space checks")
+    except IndexError, err:
+        print("...WARN: Failed to get download size from: %s" % patch_url)
+        print("         Will attempt to continue download, with unknown file size")
+        time.sleep(4)
+	###############
         size_ok = False
 
     # Check available disk space

--- a/patcher.py
+++ b/patcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Citrix XenServer Patcher
-version = "1.4.1"
+version = "1.5.1"
 # -- Designed to automatically review available patches from Citrix's XML API,
 #    compare with already installed patches, and apply as necessary- prompting the user
 #    to reboot/restart the XE ToolStack if necessary.

--- a/patcher.py
+++ b/patcher.py
@@ -310,24 +310,24 @@ def download_patch(patch_url):
 
     print "Download Size: %s Bytes" % (file_size)
         
-        file_size_dl = 0
-        block_sz = 8192
-        while True:
-            buffer = u.read(block_sz)
-            if not buffer:
-                break
-            file_size_dl += len(buffer)
-            f.write(buffer)
-            if size_ok == False:
-                 status = r"%10d" % (file_size_dl)
-            else:
-                 status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
-            status = status + chr(8)*(len(status)+1)
-            print status,
-        f.close()
-        if not os.path.isfile(file_name):
-            print("\nERROR: File download for " + str(file_name) + " unsuccessful.")
-            sys.exit(15)
+    file_size_dl = 0
+    block_sz = 8192
+    while True:
+        buffer = u.read(block_sz)
+        if not buffer:
+            break
+        file_size_dl += len(buffer)
+        f.write(buffer)
+        if size_ok == False:
+             status = r"%10d" % (file_size_dl)
+        else:
+             status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
+        status = status + chr(8)*(len(status)+1)
+        print status,
+    f.close()
+    if not os.path.isfile(file_name):
+        print("\nERROR: File download for " + str(file_name) + " unsuccessful.")
+        sys.exit(15)
     return file_name
 
 def apply_patch(name_label, uuid, file_name, host_uuid):


### PR DESCRIPTION
This has been tested, and seems to stop the Index Range Errors occuring when no Content-Length is provided by the upstream (even though it looks like it might be caused by a bug in a client library as a result of earlier updates).